### PR TITLE
fix: CORE-1393 - Ethereum watcher compatibility:

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -48,9 +48,13 @@ services:
     ethereum-watcher:
         container_name: streamr_dev_ethereum_watcher
         image: streamr/ethereum-watcher
+        restart: on-failure
         depends_on:
             - engine-and-editor
         links:
             - engine-and-editor
         environment:
             STREAMR_API_URL: http://engine-and-editor:8081/streamr-core/api/v1
+            METRICS: "false"
+        volumes:
+            - ./data/ethereum-watcher/:/app/logs


### PR DESCRIPTION
* Ethereum watcher is always restarting so it needs restart on-failure
* Set up volume to maintain lastBlock

Related: CORE-1393