### PR TITLE
Change editor port from 'unsafe' 6666 to 5555.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Url mappings:
 |---------------------|-------------------------------------|-------------------------------| 
 | `engine-and-editor` | http://localhost:8081/streamr-core  | http://localhost/streamr-core | 
 | `marketplace`       | http://localhost:3333               | http://localhost/marketplace  | 
-| `editor`            | http://localhost:6666               | http://localhost/editor       | 
+| `editor`            | http://localhost:5555               | http://localhost/editor       | 
 
 
 ## Accounts

--- a/custom-nginx-reverse-proxy.conf
+++ b/custom-nginx-reverse-proxy.conf
@@ -25,7 +25,7 @@ http {
 
         location /editor/ {
             # editor is not dockerized, refer to host
-            proxy_pass         http://host.docker.internal:6666/editor/;
+            proxy_pass         http://host.docker.internal:5555/editor/;
             proxy_redirect     off;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;


### PR DESCRIPTION
Chrome refuses to connect on port 6666, complaining about `ERR_UNSAFE_PORT`:

![image](https://user-images.githubusercontent.com/43438/41587296-75d25afa-73e1-11e8-88ae-96d5cd300ec8.png)

`5555` is not on this list:

https://src.chromium.org/viewvc/chrome/trunk/src/net/base/net_util.cc?view=markup#l70

See this for more info https://superuser.com/questions/188058/which-ports-are-considered-unsafe-on-chrome