### PR TITLE
Run e&e in dev env instead of test. Add smtp server url

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -48,8 +48,9 @@ services:
             - zookeeper
             - broker
             - data-api
+            - smtp
         entrypoint: "grails"
-        command: "-Dstreamr.database.host=mysql -Dstreamr.kafka.bootstrap.servers=kafka:9092 -Dstreamr.redis.hosts=redis -Dstreamr.cassandra.hosts=cassandra test run-app"
+        command: "-Dstreamr.database.host=mysql -Dstreamr.kafka.bootstrap.servers=kafka:9092 -Dstreamr.redis.hosts=redis -Dstreamr.cassandra.hosts=cassandra -Dgrails.mail.host=smtp run-app"
         environment:
             AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
             AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"


### PR DESCRIPTION
Do we have some reason to run the docker e&e in TEST environment? I didn't find one so changed to DEV. 
Also linked smtp server (signup works then) 