### PR TITLE
fix: CORE-1549 - Cannot run canvases in dev environment:

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,6 +33,12 @@ services:
             - zookeeper
         environment:
             STREAMR_URL: http://10.200.10.1:8081/streamr-core
+    twitter-bitcoin:
+          container_name: streamr_dev_twitter-bitcoin
+          image: streamr/twitter-bitcoin
+          restart: on-failure
+          links:
+              - data-api
     engine-and-editor:
         container_name: streamr_dev_engine-and-editor
         image: streamr/engine-and-editor:latest
@@ -47,7 +53,6 @@ services:
             - redis
             - zookeeper
             - broker
-            - data-api
         entrypoint: "grails"
         command: "-Dstreamr.database.host=mysql -Dstreamr.kafka.bootstrap.servers=kafka:9092 -Dstreamr.redis.hosts=redis -Dstreamr.cassandra.hosts=cassandra test run-app"
         environment:


### PR DESCRIPTION
* Fix data-api configuration
* Add twitter-bitcoin


Both Historical and Realtime canvases following the tutorial are fixed in dev environment.