### PR TITLE
Remove Platform Basepath Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Url mappings:
 | Service             | Original localhost url              | New url after `nginx`         |
 |---------------------|-------------------------------------|-------------------------------| 
 | `engine-and-editor` | http://localhost:8081/streamr-core  | http://localhost/streamr-core | 
-| `platform`          | http://localhost:3333               | http://localhost/platform     | 
+| `platform`          | http://localhost:3333               | http://localhost/             | 
 
 
 ## Accounts

--- a/custom-nginx-reverse-proxy.conf
+++ b/custom-nginx-reverse-proxy.conf
@@ -13,9 +13,9 @@ http {
     server {
         listen 80;
 
-        location /platform/ {
+        location / {
             # platform is not dockerized, refer to host
-            proxy_pass         http://host.docker.internal:3333/platform/;
+            proxy_pass         http://host.docker.internal:3333/;
             proxy_redirect     off;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;


### PR DESCRIPTION
This PR is linked to the streamr-platform PR: https://github.com/streamr-dev/streamr-platform/pull/230

The Streamr-Platform app will no longer have PLATFORM_BASE_PATH in favour of a true `/`root path.

This should be merged after the platform PR is ready. 