### PR TITLE
DEVOPS-61: reduce memory footprint of Cassandra

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
             - "7199:7199"
             - "9042:9042"
             - "9160:9160"
+        environment:
+            JVM_OPTS: "-Xms256M -Xmx512M"
         volumes:
             - ./data/cassandra:/var/lib/cassandra
     kafka:


### PR DESCRIPTION
Cassandra is greedy with respect to memory use. This is desired for production environments but not so much for development. 

Put a 512M limit on Cassandra's memory use. Based on preliminary tests I discovered no adverse effects. However, it could have an impact on service start up time and/or behavior under heavy load. 

Before
```
$ docker stats
CONTAINER ID        NAME                        CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
8508397212dd        streamr_dev_cassandra       2.32%               1.413GiB / 4.834GiB   29.24%              55.5MB / 984kB      0B / 885kB          78
```

After
```
$ docker stats
CONTAINER ID        NAME                        CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
f58b7138f783        streamr_dev_cassandra       1.91%               495.4MiB / 4.834GiB   10.01%              55.5MB / 953kB      0B / 885kB          79
```
