### PR TITLE
Enforce bind-ip

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -42,9 +42,9 @@ check_services_from_arguments() {
 }
 
 start() {
-    ip_lines=$( ifconfig | grep 10.200.10.1 | wc -l )
+    ip_lines=$(ifconfig | grep -c 10.200.10.1)
     if [ "$ip_lines" -eq "0" ]; then
-       echo "WARNING: bind-ip is not set! Setting it now.";
+       echo "WARNING: bind-ip is not set! Setting it now."
        bind_ip
     fi
     check_services_from_arguments

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -42,6 +42,11 @@ check_services_from_arguments() {
 }
 
 start() {
+    ip_lines=$( ifconfig | grep 10.200.10.1 | wc -l )
+    if [ "$ip_lines" -eq "0" ]; then
+       echo "WARNING: bind-ip is not set! Setting it now.";
+       bind_ip
+    fi
     check_services_from_arguments
     [[ $DETACHED == 1 ]] && FLAGS+=" -d"
     [[ $SERVICES == "" ]] && msg="Starting all" || msg="Starting$SERVICES"


### PR DESCRIPTION
Check that the internal IP address is set when `streamr-docker-dev start`:ing services, otherwise do the `bind-ip` automatically. 

I've wasted so much time debugging mystery errors caused by forgetting `bind-ip`, especially on Travis... This would have helped.