### PR TITLE
feat: DEVOPS-139 - Support local development for CP:

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -119,3 +119,4 @@ services:
             STREAMR_HTTP_URL: http://10.200.10.1:8081/streamr-core/api/v1
             TOKEN_ADDRESS: "0xbaa81a0179015be47ad439566374f2bae098686f"
             REMOTE_SECRETS: "false"
+            CP_URL: "http://host.docker.internal:8085/communities/"


### PR DESCRIPTION
* Using host.docker.internal the service can be acessabile if deployed locally or on a docker container