### PR TITLE
Remove twitter-bitcoin

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -32,12 +32,6 @@ services:
         environment:
             STREAMR_URL: http://10.200.10.1:8081/streamr-core
             CASSANDRA_HOST: 10.200.10.1:9042
-    twitter-bitcoin:
-          container_name: streamr_dev_twitter-bitcoin
-          image: streamr/twitter-bitcoin
-          restart: on-failure
-          links:
-              - broker-node
     engine-and-editor:
         container_name: streamr_dev_engine-and-editor
         image: streamr/engine-and-editor:dev


### PR DESCRIPTION
Is anything using the `twitter-bitcoin` image anymore? I think it was originally there to produce data required by functional tests of tours in the old UI. That reason is obviously now gone. 

The image is also problematic because it's private, and gives an error to anyone not logged in to our docker when they start the stack with `--all`.