### PR TITLE
nginx-reverse: add /api/v1/volume endpoint

### DIFF
--- a/custom-nginx-reverse-proxy.conf
+++ b/custom-nginx-reverse-proxy.conf
@@ -44,6 +44,13 @@ http {
             proxy_read_timeout 240s;
         }
 
+        # Data Volume endpoint
+        location /api/v1/volume {
+            add_header X-debug "/api/v1/volume";
+            proxy_pass http://brokers_http;
+            proxy_read_timeout 240s;
+        }
+
         ### API ENDPOINTS PROXIED TO ENGINE-AND-EDITOR ###
 
         location /api {


### PR DESCRIPTION
Add /api/v1/volume endpoint to nginx-reverse-proxy configuration. It redirects to broker's volume endpoint.