### PR TITLE
revert docker-compose configuration file version to 3

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3"
 services:
     nginx:
         container_name: streamr_nginx_reverse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3"
 services:
     cassandra:
         container_name: streamr_dev_cassandra


### PR DESCRIPTION
Revert docker-compose configuration file to 3 for now. Some builds within TravisCI are not running a new enough version of Docker to support version "3.7"