### PR TITLE
add smtp as dependency of EE

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -62,6 +62,7 @@ services:
             - "8081:8081"
         depends_on:
             - init_keyspace
+            - smtp
         links:
             - mysql
             - cassandra


### PR DESCRIPTION
Giving out permissions to resources won't work without smtp as dependency.