### PR TITLE
run tracker from broker image

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,10 +10,11 @@ services:
           - ./custom-nginx-reverse-proxy.conf:/etc/nginx/nginx.conf:ro
     tracker:
         container_name: streamr_dev_tracker
-        image: streamr/tracker:dev
+        image: streamr/broker-node:dev
         restart: on-failure
         ports:
             - "30300:30300"
+        command: node tracker.js
     broker-node-storage-1:
         container_name: streamr_dev_broker-node-storage-1
         image: streamr/broker-node:dev


### PR DESCRIPTION
Run tracker from broker-node image which allows us to not have to maintain two separate docker images.