### PR TITLE
Add healthcheck for platform

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -140,6 +140,11 @@ services:
             REMOTE_SECRETS: "false"
     platform:
         container_name: streamr_dev_platform
-        image: streamr/platform:development
+        image: streamr/platform:dev
+        healthcheck:
+            test: ["CMD", "curl", "-sS", "http://localhost"]
+            interval: 1m30s
+            timeout: 10s
+            retries: 3
         ports:
             - "3333:80"


### PR DESCRIPTION
Add a curl healthcheck for platform. Also fixed to use `dev` tag since `development` is not updated anymore.

I already created a nodejs healthcheck script but it would have been a mess to be run inside current container so I had to revert back to curl. The Dockerfile for platform is currently using build artifacts from travis so it has no setup for nodejs and npm. Adding those only for the healthcheck is currently a total overkill.