### PR TITLE
Update cassandra init script

### DIFF
--- a/cassandra_init_scripts/keyspace.cql
+++ b/cassandra_init_scripts/keyspace.cql
@@ -12,3 +12,8 @@ CREATE TABLE IF NOT EXISTS stream_data (
     PRIMARY KEY ((id, partition), ts, sequence_no, publisher_id, msg_chain_id)
 );
 
+create table if not exists stream_last_msg
+(
+	id text primary key,
+	time timestamp
+);


### PR DESCRIPTION
New table for getting last message timestamps. Table will be updated by network brokers.
We need to change EE to query this table, and make one more endpoint to query list of streams:
`select id, time from stream_last_msg where id in('streamId1', 'streamId2');`