### PR TITLE
Replace readlink with greadlink

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ORIG_FILENAME="$(readlink "$0" -f)"
+ORIG_FILENAME="$(greadlink "$0" -f)"
 ORIG_DIRNAME=$(dirname "$ORIG_FILENAME")
 ROOT_DIR="$ORIG_DIRNAME/.."
 CONTAINER_PREFIX="streamr-dev-"


### PR DESCRIPTION
When working with Travis builds I sometimes have to run the build
locally to simulate what happens on Travis server.

This is difficult because macOS /usr/bin/readlink is different from
Linux's readlink.

One solution is to use greadlink which can be installed with 'brew
install coreutils'. Coreutils readlink is prefixed with a 'g' on macOS.

See the difference between implementations:
kkn@kare-mbp ~/src/github.com/streamr-dev/streamr-docker-dev master U % readlink streamr-docker-dev/bin.sh -f
kkn@kare-mbp ~/src/github.com/streamr-dev/streamr-docker-dev master U % greadlink streamr-docker-dev/bin.sh -f
/Users/kkn/src/github.com/streamr-dev/streamr-docker-dev/streamr-docker-dev/bin.sh