### PR TITLE
Multi tracker

### DIFF
--- a/cassandra_init_scripts/keyspace.cql
+++ b/cassandra_init_scripts/keyspace.cql
@@ -11,9 +11,3 @@ CREATE TABLE IF NOT EXISTS stream_data (
     payload blob,
     PRIMARY KEY ((id, partition), ts, sequence_no, publisher_id, msg_chain_id)
 );
-
-create table if not exists stream_last_msg
-(
-	id text primary key,
-	time timestamp
-);

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,16 +13,42 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-    tracker:
-        container_name: streamr-dev-tracker
+    tracker-1:
+        container_name: streamr-dev-tracker-1
         image: streamr/broker-node:dev
         restart: on-failure
         ports:
-            - "30300:30300"
+            - "30301:30301"
             - "11111:11111"
-        command: node tracker.js --endpointServerPort=11111
+        command: node tracker.js --port=30301 --endpointServerPort=11111
         healthcheck:
             test: ["CMD", "curl", "-sS", "http://localhost:11111/topology/"]
+            interval: 30s
+            timeout: 10s
+            retries: 20
+    tracker-2:
+        container_name: streamr-dev-tracker-2
+        image: streamr/broker-node:dev
+        restart: on-failure
+        ports:
+            - "30302:30302"
+            - "11112:11112"
+        command: node tracker.js --port=30302 --endpointServerPort=11112
+        healthcheck:
+            test: ["CMD", "curl", "-sS", "http://localhost:11112/topology/"]
+            interval: 30s
+            timeout: 10s
+            retries: 20
+    tracker-3:
+        container_name: streamr-dev-tracker-3
+        image: streamr/broker-node:dev
+        restart: on-failure
+        ports:
+            - "30303:30303"
+            - "11113:11113"
+        command: node tracker.js --port=30303 --endpointServerPort=11113
+        healthcheck:
+            test: ["CMD", "curl", "-sS", "http://localhost:11113/topology/"]
             interval: 30s
             timeout: 10s
             retries: 20
@@ -38,7 +64,9 @@ services:
         depends_on:
             - init-keyspace
             - cassandra
-            - tracker
+            - tracker-1
+            - tracker-2
+            - tracker-3
         environment:
             STREAMR_URL: http://10.200.10.1:8081/streamr-core
             CASSANDRA_HOST: 10.200.10.1:9042
@@ -58,7 +86,9 @@ services:
             - "9100:9100"
             - "30316:30316"
         depends_on:
-            - tracker
+            - tracker-1
+            - tracker-2
+            - tracker-3
         environment:
             STREAMR_URL: http://10.200.10.1:8081/streamr-core
             CONFIG_FILE: configs/docker-2.env.json
@@ -77,7 +107,9 @@ services:
             - "9200:9200"
             - "30317:30317"
         depends_on:
-            - tracker
+            - tracker-1
+            - tracker-2
+            - tracker-3
         environment:
             STREAMR_URL: http://10.200.10.1:8081/streamr-core
             CONFIG_FILE: configs/docker-3.env.json


### PR DESCRIPTION
And I replaced original `tracker` with `tracker-1` and port `30301`, so final list of trackers is:
`tracker-1`: `30301`
`tracker-2`: `30302`
`tracker-3`: `30303`

And tested locally JS-client with new `broker` image - no issues.