### PR TITLE
Use `stable` nginx docker image

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
     nginx:
         container_name: streamr-dev-nginx
-        image: nginx:1.14-alpine
+        image: nginx:stable
         restart: on-failure
         ports:
           - "80:80"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
     nginx:
         container_name: streamr-dev-nginx
-        image: nginx:stable
+        image: nginx:stable-alpine
         restart: on-failure
         ports:
           - "80:80"


### PR DESCRIPTION
This appears to fix connection refused/timeout issues during tests.

Not sure exactly which fix cured it: https://nginx.org/en/CHANGES

Also possible this should be `stable-alpine`?