### PR TITLE
Fail hung proxy connections faster.

### DIFF
--- a/custom-nginx-reverse-proxy.conf
+++ b/custom-nginx-reverse-proxy.conf
@@ -43,6 +43,7 @@ http {
     }
 
     server {
+        proxy_connect_timeout 10s;
 
         listen 80;
 


### PR DESCRIPTION
Unfortunately, I'm still seeing some hung connections, even with latest nginx. Happens less regularly but they still seem to be there. Connection to upstream services shouldn't take 10+ seconds. Note this timeout is for establishing a connection only, not for response.

When docker starts playing up, then this makes things fail faster.
Could probably even be down to 3s or lower.