### PR TITLE
DEVOP-56: Remove deprecated Docker compose option

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -16,7 +16,7 @@ DRY_RUN=0
 FOLLOW=0
 WAIT=0
 WAIT_TIMEOUT=300     # seconds
-DOCKER_COMPOSE="docker-compose --no-ansi"
+DOCKER_COMPOSE="docker-compose" 
 
 # Execute all commands from the root dir of streamr-docker-dev
 cd "$ROOT_DIR" || exit 1

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -16,7 +16,7 @@ DRY_RUN=0
 FOLLOW=0
 WAIT=0
 WAIT_TIMEOUT=300     # seconds
-DOCKER_COMPOSE="docker-compose" 
+DOCKER_COMPOSE="docker-compose --ansi never"
 
 # Execute all commands from the root dir of streamr-docker-dev
 cd "$ROOT_DIR" || exit 1


### PR DESCRIPTION
--no-ansi is being deprecated, gives warnings in the command-line

https://docs.docker.com/compose/cli-command-compatibility/
https://github.com/docker/compose/blob/master/compose/cli/main.py#L174