### PR TITLE
NET-80: Clients should not connect directly to storage node

### DIFF
--- a/custom-nginx-reverse-proxy.conf
+++ b/custom-nginx-reverse-proxy.conf
@@ -21,13 +21,11 @@ http {
     upstream brokers_ws {
         server 10.200.10.1:8690;
         server 10.200.10.1:8790;
-        server 10.200.10.1:8890;
     }
 
     upstream brokers_http {
         server 10.200.10.1:8691;
         server 10.200.10.1:8791;
-        server 10.200.10.1:8891;
     }
 
     upstream mainchain_rpc_http {


### PR DESCRIPTION
Remove WS and HTTP endpoints for storage node in NGINX config.