### PR TITLE
Use named volumes instead of bind volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - "9042:9042"
             - "9160:9160"
         volumes:
-            - ./data/cassandra:/var/lib/cassandra
+            - data-cassandra:/var/lib/cassandra
         healthcheck:
             test: ["CMD", "cqlsh", "-e", "SHOW HOST"]
             interval: 10s
@@ -31,7 +31,7 @@ services:
         ports:
             - "3306:3306"
         volumes:
-            - ./data/mysql:/var/lib/mysql:rw
+            - data-mysql:/var/lib/mysql:rw
             - ./mysql_init_scripts:/docker-entrypoint-initdb.d
             - ./custom-mysql-settings.cnf:/etc/mysql/conf.d/custom-mysql-settings.cnf
         restart: on-failure
@@ -208,7 +208,7 @@ services:
             MARKETPLACE_ADDRESS: "0xf1371c0f40528406dc4f4caf89924ea9da49e866"
             DEVOPS_KEY: "devops-user-key"
         volumes:
-            - ./data/ethereum-watcher/:/app/logs
+            - data-ethereum-watcher/:/app/logs
         healthcheck:
             test: ["CMD", "echo"] # TODO: Health check
             interval: 10s
@@ -282,7 +282,7 @@ services:
             retries: 3
          command: --chain ./streamr-spec.json --config ./node0.toml
          volumes:
-           - ./data/parity-node0/:/home/parity/parity_data
+           - data-parity-node0/:/home/parity/parity_data
     parity-sidechain-node0:
          container_name: streamr-dev-parity-sidechain-node0
          environment:
@@ -300,7 +300,7 @@ services:
             retries: 3
          command: --chain ./streamr-spec.json --config ./node0.toml
          volumes:
-           - ./data/parity-sidechain-node0/:/home/parity/parity_data
+           - data-parity-sidechain-node0/:/home/parity/parity_data
     hsl-demo:
         restart: on-failure
         container_name: streamr-dev-hsl-demo
@@ -325,7 +325,7 @@ services:
             - net_rabbit_bridge_senderhome
             - net_rabbit_bridge_senderforeign
         restart: unless-stopped
-        volumes: ['./data/bridge_data/rabbitmq:/var/lib/rabbitmq/mnesia']
+        volumes: ['data-bridge-data-rabbitmq:/var/lib/rabbitmq/mnesia']
         healthcheck:
             test: ["CMD", "echo"] # TODO: health check
             interval: 10s
@@ -341,7 +341,7 @@ services:
             - net_db_bridge_senderhome
             - net_db_bridge_senderforeign
         restart: unless-stopped
-        volumes: ['./data/bridge_data/redis:/data']
+        volumes: ['data-bridge-data-redis:/data']
         healthcheck:
             test: ["CMD", "echo"] # TODO: health check
             interval: 10s
@@ -432,6 +432,13 @@ networks:
         driver: bridge
 
 volumes:
-    data:
     mysql_init_scripts:
     cassandra_init_scripts:
+    cassandra_init_scripts:
+    data-bridge-data-rabbitmq:
+    data-bridge-data-redis:
+    data-mysql:
+    data-cassandra:
+    data-parity-node0:
+    data-parity-sidechain-node0:
+    data-ethereum-watcher:

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -171,7 +171,7 @@ update() {
 wipe() {
     stop
     COMMANDS_TO_RUN+=("echo Wiping persistent data of services")
-    COMMANDS_TO_RUN+=("docker volume prune")
+    COMMANDS_TO_RUN+=("docker volume prune -f")
 }
 
 factory-reset() {

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -171,7 +171,7 @@ update() {
 wipe() {
     stop
     COMMANDS_TO_RUN+=("echo Wiping persistent data of services")
-    COMMANDS_TO_RUN+=("rm -rf ./data")
+    COMMANDS_TO_RUN+=("docker volume prune")
 }
 
 factory-reset() {


### PR DESCRIPTION
I've converted the bind mounts that don't need to be initialised with data into named volumes.

We might want to convert the remaining bind mounts to named volumes and figure out how [populate these using a container](https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container).

Currently `certs` isn't really used, possible this could be removed, going to leave it as-is for now.


>  Volumes on Docker Desktop have much higher performance than bind mounts from Mac and Windows hosts.

https://docs.docker.com/storage/volumes/

I can not confirm that this change actually results in concrete performance improvement yet, but tests seem to work.

## Motivation

I contacted Docker Support about some persistent issues I've been having with docker. I pointed them at `streamr-docker-dev` and their first bit of feedback seems like a good suggestion:

> We've been experimenting with your scripts, but have been struggling to run them too. We find that the whole system is overloaded, and that docker commands freeze as well as docker-compose commands. Maybe we're running on less powerful hardware than you, but it's not running successfully.

> We have sometimes seen effects like this when there is a lot of file I/O. When looking into this, I was wondering whether all of the volumes: in your compose file actually need to be bind mounts, or whether some of them could be named volumes. File access across the VM boundary is not very performant, so it's suitable for something like source code where you need access to it from the host as well as the containers, but data volumes that are only read and written from containers (and possibly have high I/O) are normally better as named volumes. I wonder if it would help you to convert them?
