### PR TITLE
Remove orphan containers on up.

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -84,6 +84,8 @@ start() {
         FLAGS+=" --scale $service=0"
     done
 
+    FLAGS+=" --remove-orphans"
+
     COMMANDS_TO_RUN+=("echo $msg")
     COMMANDS_TO_RUN+=("$DOCKER_COMPOSE up $FLAGS $SERVICES")
 


### PR DESCRIPTION
Latest changes renames containers, this will automatically remove any orphaned containers on `docker-compose up` 