### PR TITLE
simplify naming of broker nodes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,8 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-    broker-node-storage-1:
-        container_name: streamr-dev-broker-node-storage-1
+    broker-1:
+        container_name: streamr-dev-broker-1
         image: streamr/broker-node:dev
         restart: unless-stopped
         ports:
@@ -119,8 +119,8 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-    broker-node-no-storage-1:
-        container_name: streamr-dev-broker-node-no-storage-1
+    broker-2:
+        container_name: streamr-dev-broker-2
         image: streamr/broker-node:dev
         restart: unless-stopped
         ports:
@@ -140,8 +140,8 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-    broker-node-no-storage-2:
-        container_name: streamr-dev-broker-node-no-storage-2
+    broker-3:
+        container_name: streamr-dev-broker-3
         image: streamr/broker-node:dev
         restart: unless-stopped
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,8 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-    broker-1:
-        container_name: streamr-dev-broker-1
+    storage:
+        container_name: streamr-dev-storage
         image: streamr/broker-node:dev
         restart: unless-stopped
         ports:
@@ -119,8 +119,8 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-    broker-2:
-        container_name: streamr-dev-broker-2
+    broker-1:
+        container_name: streamr-dev-broker-1
         image: streamr/broker-node:dev
         restart: unless-stopped
         ports:
@@ -140,8 +140,8 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-    broker-3:
-        container_name: streamr-dev-broker-3
+    broker-2:
+        container_name: streamr-dev-broker-2
         image: streamr/broker-node:dev
         restart: unless-stopped
         ports:


### PR DESCRIPTION
It's painful to always have to type out `streamr-docker-dev ... broker-node-no-storage-1 broker-node-no-storage-2 broker-node-storage-1`. The naming is also a bit unintuitive with regards to the numbering. Just simplify to `broker-1 broker-2 broker-3`, with `broker-1` being the storage node. This is in line with how trackers are named. This change will probably break some github action jobs that need to be updated.