### PR TITLE
Service Aliases

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -21,6 +21,22 @@ DOCKER_COMPOSE="docker-compose --ansi never"
 # don't start these services unless explicitly started
 EXCEPT_SERVICES_DEFAULT=() # array of string e.g. ("a" "b")
 
+# Service Aliases
+NODE_NO_STORAGE='broker-node-no-storage-1 broker-node-no-storage-2'
+NODE_STORAGE='broker-node-storage-1'
+NODES="$NODE_NO_STORAGE $NODE_STORAGE"
+TRACKERS='tracker-1 tracker-2 tracker-3'
+
+# swap aliases for full names e.g. trackers = tracker-1 tracker-2 tracker-3
+expandServiceAliases() {
+    local names=$1
+    names="${names/broker-no-storage/$BROKER_NO_STORAGE}"
+    names="${names/broker-storage/$BROKER_STORAGE}"
+    names="${names/brokers/$BROKERS}"
+    names="${names/trackers/$TRACKERS}"
+    echo "$names"
+}
+
 # Execute all commands from the root dir of streamr-docker-dev
 cd "$ROOT_DIR" || exit 1
 
@@ -237,6 +253,10 @@ while [ $# -gt 0 ]; do # if there are arguments
     fi
     shift
 done
+
+EXCEPT_SERVICES_DEFAULT=($(expandServiceAliases "${EXCEPT_SERVICES_DEFAULT[*]}"))
+SERVICES=$(expandServiceAliases "$SERVICES")
+EXCEPT_SERVICES=($(expandServiceAliases "${EXCEPT_SERVICES[*]}"))
 
 # Populate COMMANDS_TO_RUN by executing the relevant method
 case $OPERATION in

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -28,6 +28,8 @@ NODES="$NODE_NO_STORAGE $NODE_STORAGE"
 TRACKERS='tracker-1 tracker-2 tracker-3'
 
 # swap aliases for full names e.g. trackers = tracker-1 tracker-2 tracker-3
+# feel free to add more, just make sure you don't end up using actual service
+# names as alias names
 expandServiceAliases() {
     local names=$1
     names="${names//node-no-storage/$NODE_NO_STORAGE}"
@@ -35,7 +37,7 @@ expandServiceAliases() {
     names="${names//node-storage/$NODE_STORAGE}"
     names="${names//storage-nodes/$NODE_STORAGE}"
     names="${names//brokers/$NODES}"
-    names="${names//nodes/$NODES}"
+    names="${names//nodes/$NODES}" # brokers/nodes sort of interchangeable
     names="${names//trackers/$TRACKERS}"
     echo "$names"
 }

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -30,10 +30,13 @@ TRACKERS='tracker-1 tracker-2 tracker-3'
 # swap aliases for full names e.g. trackers = tracker-1 tracker-2 tracker-3
 expandServiceAliases() {
     local names=$1
-    names="${names/broker-no-storage/$BROKER_NO_STORAGE}"
-    names="${names/broker-storage/$BROKER_STORAGE}"
-    names="${names/brokers/$BROKERS}"
-    names="${names/trackers/$TRACKERS}"
+    names="${names//node-no-storage/$NODE_NO_STORAGE}"
+    names="${names//no-storage-nodes/$NODE_NO_STORAGE}"
+    names="${names//node-storage/$NODE_STORAGE}"
+    names="${names//storage-nodes/$NODE_STORAGE}"
+    names="${names//brokers/$NODES}"
+    names="${names//nodes/$NODES}"
+    names="${names//trackers/$TRACKERS}"
     echo "$names"
 }
 

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -47,6 +47,10 @@ help() {
     "$ORIG_DIRNAME/help_scripts.sh" $SERVICES
 }
 
+services() {
+    $DOCKER_COMPOSE config --services
+}
+
 start() {
     ip_lines=$(ifconfig | grep -c 10.200.10.1)
     if [ "$ip_lines" -eq "0" ]; then
@@ -271,6 +275,9 @@ wipe )
     ;;
 factory-reset )
     factory-reset
+    ;;
+services )
+    services
     ;;
 * )
     help

--- a/streamr-docker-dev/help_scripts.sh
+++ b/streamr-docker-dev/help_scripts.sh
@@ -10,6 +10,7 @@ Commands:
     help                show this screen
     start               start services
     stop                stop services
+    services            list all services
     restart             stop and start services
     wait                wait for all health checks to pass
     ps                  list docker containers


### PR DESCRIPTION
This should make starting and stopping collections of related services easier.

* Maintains existing service naming, only adds new aliases.
* Aliases should work automatically with all commands, including `stop`, `restart`, `log` and `--except` flag.
* Aliases will also work automatically for new commands, but may require some special handling if adding a new `--flag`.
* Easy enough to add new aliases. Please do add more if your work regularly requires starting & stopping a particular set of services.

## Examples

#### Start Trackers
```bash
sdd start trackers
# sdd start tracker-1 tracker-2 tracker-3
```

#### Start Brokers (Nodes)

```bash
sdd start nodes # equivalent to sdd start brokers (also works)
# sdd broker-node-no-storage-1 broker-node-no-storage-2 broker-node-storage-1 
```

#### Start Brokers & Trackers
```bash
sdd start brokers trackers
# sdd start broker-node-no-storage-1 broker-node-no-storage-2 broker-node-storage-1 tracker-1 tracker-2 tracker-3
```

#### Log Only Brokers

```bash
sdd log -f brokers
# sdd log -f broker-node-no-storage-1 broker-node-no-storage-2 broker-node-storage-1
```

#### Start Non-Storage Nodes

```bash
sdd start no-storage-nodes
# sdd start broker-node-no-storage-1 broker-node-no-storage-2
```

#### Start Storage Node(s)

```bash
sdd start storage-nodes
# sdd start broker-node-storage-1
```

#### Start all except brokers and trackers

```bash
sdd start --except brokers --except trackers
# sdd start --except broker-node-no-storage-1 --except broker-node-no-storage-2 --except broker-node-storage-1 --except tracker-1 --except tracker-2 --except tracker-3
```

## Caveats

* Works via very simple string substitution on list of services, no word boundary detection, so does open door for weird double-processing if the thing you substitute also matches another alias, or if the alias appears inside a service name. Need to be careful when adding new services that they don't match an existing alias.
* Aliases are only documented in source, not listed in help currently, but broken windows, the list of services isn't in help either. I tried briefly but didn't see an easy way to do the reverse lookup needed to autogenerate the the list of aliases. The one option I did find, using an array of arrays, required a newer version of bash 4.x which doesn't ship by default on macos 3.x :/

**If you want to check exactly what command will be run**, and thus which services will be started/stopped/etc, you can always use `--dry-run`.

See here for aliases: https://github.com/streamr-dev/streamr-docker-dev/blob/52b78082c2dc6702ba459e793667de986cc1200f/streamr-docker-dev/bin.sh#L24-L43




