### PR TITLE
Allow connecting to storage via nginx.

### DIFF
--- a/custom-nginx-reverse-proxy.conf
+++ b/custom-nginx-reverse-proxy.conf
@@ -29,6 +29,10 @@ http {
         server 10.200.10.1:8791;
     }
 
+    upstream storage_http {
+        server 10.200.10.1:8891;
+    }
+
     upstream mainchain_rpc_http {
         server 10.200.10.1:8545;
     }
@@ -81,7 +85,7 @@ http {
         # Data REST endpoints
         location ~ /api/v1/streams/(.*)/(data|data/partitions/.*)$ {
             add_header X-debug "/api/v1/streams";
-            proxy_pass http://brokers_http;
+            proxy_pass http://storage_http;
             proxy_read_timeout 240s;
         }
 


### PR DESCRIPTION
This partially rolls back the "must connect to storage directly" change.
Client tests aren't passing because nothing can query `/data/` because everything is still pointing at the rest url.
Going to require more work to make this sensible, let's just restore tests to a passing state before tackling this.

Related: https://linear.app/streamr/issue/NET-279/automatically-connecting-to-streams-storage-node