### PR TITLE
Fix bad alias

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -32,9 +32,9 @@ TRACKERS='tracker-1 tracker-2 tracker-3'
 # names as alias names
 expandServiceAliases() {
     local names=$1
+    # aliases should be plural to reduce possibility of conflicts with service names
     names="${names//node-no-storage/$NODE_NO_STORAGE}"
     names="${names//no-storage-nodes/$NODE_NO_STORAGE}"
-    names="${names//node-storage/$NODE_STORAGE}"
     names="${names//storage-nodes/$NODE_STORAGE}"
     names="${names//brokers/$NODES}"
     names="${names//nodes/$NODES}" # brokers/nodes sort of interchangeable


### PR DESCRIPTION
Prevents `broker-node-no-storage-1` being aliased to `broker-broker-node-no-storage-1`.

All other aliases are plural so this can't happen again, unless a service is plural.