### PR TITLE
map new storage broker API endpoint (and old metadata one)

### DIFF
--- a/custom-nginx-reverse-proxy.conf
+++ b/custom-nginx-reverse-proxy.conf
@@ -83,7 +83,7 @@ http {
         }
 
         # Data REST endpoints
-        location ~ /api/v1/streams/(.*)/(data|data/partitions/.*)$ {
+        location ~ /api/v1/streams/(.*)/(data|metadata/partitions/.*|storage/partitions/.*|data/partitions/.*)$ {
             add_header X-debug "/api/v1/streams";
             proxy_pass http://storage_http;
             proxy_read_timeout 240s;


### PR DESCRIPTION
- Map `/api/v1/streams/:streamId/storage/partitions/:partition` to storage node.
- Map `/api/v1/streams/:streamId/metadata/partitions/:partition` to storage node.