### PR TITLE
fix: add timeout to curl healtcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -387,8 +387,8 @@ services:
         deploy:
             resources:
                 limits:
-                    cpus: '0.50'
-                    memory: 300M
+                    cpus: '2.00'
+                    memory: 500M
                 reservations:
                     memory: 100M
     data-union-server:
@@ -466,7 +466,7 @@ services:
         deploy:
             resources:
                 limits:
-                    cpus: '1.0'
+                    cpus: '2.0'
                     memory: 2000M
                 reservations:
                     memory: 10M


### PR DESCRIPTION
Prevents curl from becoming a zombie process of sorts that doesn't time
out in GitHub Actions box.

Also add --fail to make the check to fail on status code != 200.