### PR TITLE
Use init: true to allow services to exit cleanly.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     cassandra:
         container_name: streamr-dev-cassandra
         image: streamr/cassandra:v0.0.1
+        init: true
         networks:
             - streamr-network
         ports:
@@ -29,6 +30,7 @@ services:
     init-keyspace:
         container_name: streamr-dev-init-keyspace
         image: cassandra:3.11.5
+        init: true
         networks:
             - streamr-network
         command: bash -c "sleep 5 && cqlsh cassandra -f /init_scripts/keyspace.cql && echo keyspace initialized"
@@ -52,6 +54,7 @@ services:
     mysql:
         container_name: streamr-dev-mysql
         image: streamr/mysql:v0.0.1
+        init: true
         networks:
             - streamr-network
         ports:
@@ -151,6 +154,7 @@ services:
     tracker-1:
         container_name: streamr-dev-tracker-1
         image: streamr/broker-node:dev
+        init: true
         networks:
             - streamr-network
         restart: unless-stopped
@@ -179,6 +183,7 @@ services:
     tracker-2:
         container_name: streamr-dev-tracker-2
         image: streamr/broker-node:dev
+        init: true
         networks:
             - streamr-network
         restart: unless-stopped
@@ -207,6 +212,7 @@ services:
     tracker-3:
         container_name: streamr-dev-tracker-3
         image: streamr/broker-node:dev
+        init: true
         networks:
             - streamr-network
         restart: unless-stopped
@@ -235,6 +241,7 @@ services:
     broker-node-storage-1:
         container_name: streamr-dev-broker-node-storage-1
         image: streamr/broker-node:dev
+        init: true
         networks:
             - streamr-network
         restart: unless-stopped
@@ -268,6 +275,7 @@ services:
     broker-node-no-storage-1:
         container_name: streamr-dev-broker-node-no-storage-1
         image: streamr/broker-node:dev
+        init: true
         networks:
             - streamr-network
         restart: unless-stopped
@@ -298,6 +306,7 @@ services:
     broker-node-no-storage-2:
         container_name: streamr-dev-broker-node-no-storage-2
         image: streamr/broker-node:dev
+        init: true
         networks:
             - streamr-network
         restart: unless-stopped
@@ -361,6 +370,7 @@ services:
     ethereum-watcher:
         container_name: streamr-dev-ethereum-watcher
         image: streamr/ethereum-watcher:dev
+        init: true
         networks:
             - streamr-network
         restart: unless-stopped
@@ -394,6 +404,7 @@ services:
     data-union-server:
         container_name: streamr-dev-data-union-server
         image: streamr/data-union-server:dev
+        init: true
         networks:
             - streamr-network
         ports:
@@ -595,6 +606,7 @@ services:
     bridge-senderhome:
         container_name: streamr-dev-bridge-senderhome
         image: poanetwork/tokenbridge-oracle:latest
+        init: true
         networks:
             - streamr-network
         env_file:


### PR DESCRIPTION
Recently I've been seeing these "Cannot kill container" types of errors when stopping stuff with streamr-docker-dev.

```
ERROR: for streamr-dev-broker-node-no-storage-2  Cannot kill container: df11508e916d223b4b44f3124b88753b83c757473dc6fa39d72eed44be9cfd85: container df11508e916d PID 50488 is zombie and can not be killed. Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes
```

The error message recommends adding `init`.
This PR adds it to every service.

### Docker init reference:

https://docs.docker.com/compose/compose-file/compose-file-v3/#init

### What init (`tini`) does:

https://github.com/krallin/tini/issues/8#issuecomment-146135930