### PR TITLE
network-explorer: remove open stdin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -454,7 +454,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        stdin_open: true
         deploy:
             resources:
                 limits:


### PR DESCRIPTION
This was forgotten. @tumppi It should be safe to remove now?