### PR TITLE
feat: move limits to docker-compose-ci.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint-yaml: $(YAMLLINT)
 
 .PHONY: test-smoke
 test-smoke:
-	docker-compose -f docker-compose.yml config
+	docker-compose -f docker-compose.yml -f docker-compose-ci.yml config
 
 .PHONY: test-docker-dev
 test-docker-dev:

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,0 +1,262 @@
+---
+version: "3.8"
+services:
+    cassandra:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 3G
+                reservations:
+                    memory: 1.7G
+    init-keyspace:
+        deploy:
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 100M
+                reservations:
+                    memory: 6M
+    mysql:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 500M
+                reservations:
+                    memory: 250M
+    redis:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.50'
+                    memory: 50M
+                reservations:
+                    memory: 20M
+    smtp:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.2'
+                    memory: 30M
+                reservations:
+                    memory: 10M
+    nginx:
+        deploy:
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 500M
+                reservations:
+                    memory: 6M
+    tracker-1:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 200M
+                reservations:
+                    memory: 150M
+    tracker-2:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 200M
+                reservations:
+                    memory: 150M
+    tracker-3:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 200M
+                reservations:
+                    memory: 150M
+    broker-node-storage-1:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 200M
+                reservations:
+                    memory: 150M
+    broker-node-no-storage-1:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 200M
+                reservations:
+                    memory: 150M
+    broker-node-no-storage-2:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 200M
+                reservations:
+                    memory: 150M
+    core-api:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.0'
+                    memory: 1500M
+                reservations:
+                    memory: 500M
+    ethereum-watcher:
+        deploy:
+            resources:
+                limits:
+                    cpus: '2.00'
+                    memory: 500M
+                reservations:
+                    memory: 100M
+    data-union-server:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.50'
+                    memory: 100M
+                reservations:
+                    memory: 10M
+    platform:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.50'
+                    memory: 50M
+                reservations:
+                    memory: 10M
+    network-explorer:
+        deploy:
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 50M
+                reservations:
+                    memory: 10M
+    parity-node0:
+        deploy:
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 100M
+                reservations:
+                    memory: 20M
+    parity-sidechain-node0:
+        deploy:
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 100M
+                reservations:
+                    memory: 20M
+    bridge-rabbitmq:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.5'
+                    memory: 150M
+                reservations:
+                    memory: 50M
+    bridge-request:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.5'
+                    memory: 100M
+                reservations:
+                    memory: 10M
+    bridge-affirmation:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.5'
+                    memory: 100M
+                reservations:
+                    memory: 10M
+    bridge-senderhome:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.5'
+                    memory: 100M
+                reservations:
+                    memory: 10M
+    bridge-senderforeign:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.5'
+                    memory: 100M
+                reservations:
+                    memory: 10M
+    bridge:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.1'
+                    memory: 10M
+                reservations:
+                    memory: 10M
+    graph-node:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.5'
+                    memory: 200M
+                reservations:
+                    memory: 20M
+    graph-deploy-streamregistry-subgraph:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.5'
+                    memory: 200M
+                reservations:
+                    memory: 20M
+    graph-deploy-dataunion-subgraph:
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.5'
+                    memory: 200M
+                reservations:
+                    memory: 20M
+    ipfs:
+        deploy:
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 150M
+                reservations:
+                    memory: 10M
+    postgres:
+        deploy:
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 100M
+                reservations:
+                    memory: 10M
+    chainlink:
+        deploy:
+            restart_policy:
+                condition: on-failure
+                max_attempts: 5
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 1G
+                reservations:
+                    memory: 50M
+    chainlink-external-adapter:
+        deploy:
+            resources:
+                limits:
+                    cpus: '1.0'
+                    memory: 1G
+                reservations:
+                    memory: 50M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,6 @@ services:
               volume:
                   nocopy: true
         restart: unless-stopped
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 3G
-                reservations:
-                    memory: 1.7G
     init-keyspace:
         container_name: streamr-dev-init-keyspace
         image: cassandra:3.11.5
@@ -42,13 +35,6 @@ services:
                   propagation: rprivate
         depends_on:
             - cassandra
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 100M
-                reservations:
-                    memory: 6M
     mysql:
         container_name: streamr-dev-mysql
         image: streamr/mysql:v0.0.1
@@ -77,13 +63,6 @@ services:
         restart: unless-stopped
         environment:
             MYSQL_ROOT_PASSWORD: password
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 500M
-                reservations:
-                    memory: 250M
     redis:
         container_name: streamr-dev-redis
         image: streamr/redis:v0.0.1
@@ -98,13 +77,6 @@ services:
               target: /data
               volume:
                   nocopy: true
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.50'
-                    memory: 50M
-                reservations:
-                    memory: 20M
     smtp:
         container_name: streamr-dev-smtp
         image: streamr/smtp:v0.0.1
@@ -112,13 +84,6 @@ services:
             - streamr-network
         ports:
             - "25:25"
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.2'
-                    memory: 30M
-                reservations:
-                    memory: 10M
     nginx:
         container_name: streamr-dev-nginx
         image: streamr/nginx:v0.0.3
@@ -141,13 +106,6 @@ services:
               read_only: true
               bind:
                   propagation: rprivate
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 500M
-                reservations:
-                    memory: 6M
     tracker-1:
         container_name: streamr-dev-tracker-1
         image: streamr/broker-node:dev
@@ -169,13 +127,6 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 200M
-                reservations:
-                    memory: 150M
     tracker-2:
         container_name: streamr-dev-tracker-2
         image: streamr/broker-node:dev
@@ -197,13 +148,6 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 200M
-                reservations:
-                    memory: 150M
     tracker-3:
         container_name: streamr-dev-tracker-3
         image: streamr/broker-node:dev
@@ -225,13 +169,6 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 200M
-                reservations:
-                    memory: 150M
     broker-node-storage-1:
         container_name: streamr-dev-broker-node-storage-1
         image: streamr/broker-node:dev
@@ -258,13 +195,6 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 200M
-                reservations:
-                    memory: 150M
     broker-node-no-storage-1:
         container_name: streamr-dev-broker-node-no-storage-1
         image: streamr/broker-node:dev
@@ -288,13 +218,6 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 200M
-                reservations:
-                    memory: 150M
     broker-node-no-storage-2:
         container_name: streamr-dev-broker-node-no-storage-2
         image: streamr/broker-node:dev
@@ -318,13 +241,6 @@ services:
             interval: 30s
             timeout: 10s
             retries: 20
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 200M
-                reservations:
-                    memory: 150M
     core-api:
         container_name: streamr-dev-core-api
         image: streamr/core-api:dev
@@ -351,13 +267,6 @@ services:
             HTTPS_API_SERVER: "${STREAMR_BASE_URL}/api/v1"
             WS_SERVER: "${STREAMR_WS_URL}"
             CPS_URL: "http://10.200.10.1:8085/dataunions/"
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.0'
-                    memory: 1500M
-                reservations:
-                    memory: 500M
     ethereum-watcher:
         container_name: streamr-dev-ethereum-watcher
         image: streamr/ethereum-watcher:dev
@@ -384,13 +293,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '2.00'
-                    memory: 500M
-                reservations:
-                    memory: 100M
     data-union-server:
         container_name: streamr-dev-data-union-server
         image: streamr/data-union-server:dev
@@ -411,13 +313,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.50'
-                    memory: 100M
-                reservations:
-                    memory: 10M
     platform:
         container_name: streamr-dev-platform
         image: streamr/platform:dev
@@ -435,13 +330,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.50'
-                    memory: 50M
-                reservations:
-                    memory: 10M
     network-explorer:
         container_name: streamr-dev-network-explorer
         image: streamr/network-explorer:dev
@@ -455,13 +343,6 @@ services:
             timeout: 10s
             retries: 60
         stdin_open: true
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 50M
-                reservations:
-                    memory: 10M
     parity-node0:
         container_name: streamr-dev-parity-node0
         environment:
@@ -486,13 +367,6 @@ services:
               target: /home/parity/parity_data
               volume:
                   nocopy: true
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 100M
-                reservations:
-                    memory: 20M
     parity-sidechain-node0:
         container_name: streamr-dev-parity-sidechain-node0
         environment:
@@ -517,13 +391,6 @@ services:
               target: /home/parity/parity_data
               volume:
                   nocopy: true
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 100M
-                reservations:
-                    memory: 20M
     bridge-rabbitmq:
         container_name: streamr-dev-bridge-rabbitmq
         environment: ['RABBITMQ_NODENAME=node@bridge-rabbitmq']
@@ -543,13 +410,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.5'
-                    memory: 150M
-                reservations:
-                    memory: 50M
     bridge-request:
         container_name: streamr-dev-bridge-request
         image: poanetwork/tokenbridge-oracle:latest
@@ -564,13 +424,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.5'
-                    memory: 100M
-                reservations:
-                    memory: 10M
     bridge-affirmation:
         container_name: streamr-dev-bridge-affirmation
         image: poanetwork/tokenbridge-oracle:latest
@@ -585,13 +438,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.5'
-                    memory: 100M
-                reservations:
-                    memory: 10M
     bridge-senderhome:
         container_name: streamr-dev-bridge-senderhome
         image: poanetwork/tokenbridge-oracle:latest
@@ -606,13 +452,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.5'
-                    memory: 100M
-                reservations:
-                    memory: 10M
     bridge-senderforeign:
         container_name: streamr-dev-bridge-senderforeign
         image: poanetwork/tokenbridge-oracle:latest
@@ -627,13 +466,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.5'
-                    memory: 100M
-                reservations:
-                    memory: 10M
     bridge:
         container_name: streamr-dev-bridge
         image: tianon/true  # dummy image that does nothing
@@ -646,13 +478,6 @@ services:
             - bridge-rabbitmq
             - redis
             - bridge-request
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.1'
-                    memory: 10M
-                reservations:
-                    memory: 10M
     graph-node:
         container_name: streamr-dev-thegraph-node
         image: graphprotocol/graph-node
@@ -681,13 +506,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.5'
-                    memory: 200M
-                reservations:
-                    memory: 20M
     graph-deploy-streamregistry-subgraph:
         container_name: streamr-dev-graph-deploy-streamreg-subgraph
         image: streamr/graph-deploy-streamregistry-subgraph:dev
@@ -701,13 +519,6 @@ services:
               target: /firstrun
               volume:
                   nocopy: true
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.5'
-                    memory: 200M
-                reservations:
-                    memory: 20M
     graph-deploy-dataunion-subgraph:
         container_name: streamr-dev-graph-deploy-dataunion-subgraph
         image: streamr/graph-deploy-dataunion-subgraph:dev
@@ -721,13 +532,6 @@ services:
               target: /firstrun
               volume:
                   nocopy: true
-        deploy:
-            resources:
-                limits:
-                    cpus: '0.5'
-                    memory: 200M
-                reservations:
-                    memory: 20M
     ipfs:
         container_name: streamr-dev-ipfs
         image: ipfs/go-ipfs:v0.4.23
@@ -746,13 +550,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 150M
-                reservations:
-                    memory: 10M
     postgres:
         container_name: streamr-dev-postgres
         image: postgres
@@ -782,13 +579,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 100M
-                reservations:
-                    memory: 10M
     chainlink:
         container_name: streamr-dev-chainlink-node
         image: smartcontract/chainlink:0.10.5
@@ -815,16 +605,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            restart_policy:
-                condition: on-failure
-                max_attempts: 5
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 1G
-                reservations:
-                    memory: 50M
     chainlink-external-adapter:
         container_name: streamr-dev-chainlink-adapter
         image: streamr/chainlink-external-adapter:dev
@@ -839,13 +619,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 1G
-                reservations:
-                    memory: 50M
 
 networks:
     streamr-network:

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -16,7 +16,10 @@ DRY_RUN=0
 FOLLOW=0
 WAIT=0
 WAIT_TIMEOUT=300     # seconds
-DOCKER_COMPOSE="docker-compose --ansi never"
+DOCKER_COMPOSE="docker-compose --ansi never -f docker-compose.yml"
+if [ -n "${CI-}" ]; then # Apply CI override when running on CI server
+	DOCKER_COMPOSE="$DOCKER_COMPOSE -f docker-compose-ci.yml"
+fi
 
 # don't start these services unless explicitly started
 EXCEPT_SERVICES_DEFAULT=() # array of string e.g. ("a" "b")


### PR DESCRIPTION
Limits seem battle tested enough so it's a good time to move those to their own Docker compose override file: `docker-compose-ci.yml` and let developers enjoy all available resources locally.

`docker-compose-ci.yml` is the place to set CI specific settings.