### PR TITLE
fixed bug with graph-deployment containers deploying subgraphs on eve…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -528,6 +528,8 @@ services:
             - type: volume
               source: data-graph-deploy
               target: /firstrun
+              volume:
+                  nocopy: false
     graph-deploy-dataunion-subgraph:
         container_name: streamr-dev-graph-deploy-dataunion-subgraph
         image: streamr/graph-deploy-dataunion-subgraph:dev
@@ -539,6 +541,8 @@ services:
             - type: volume
               source: data-graph-deploy-dataunion
               target: /firstrun
+              volume:
+                  nocopy: false
     ipfs:
         container_name: streamr-dev-ipfs
         image: ipfs/go-ipfs:v0.11.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -528,8 +528,6 @@ services:
             - type: volume
               source: data-graph-deploy
               target: /firstrun
-              volume:
-                  nocopy: true
     graph-deploy-dataunion-subgraph:
         container_name: streamr-dev-graph-deploy-dataunion-subgraph
         image: streamr/graph-deploy-dataunion-subgraph:dev
@@ -541,8 +539,6 @@ services:
             - type: volume
               source: data-graph-deploy-dataunion
               target: /firstrun
-              volume:
-                  nocopy: true
     ipfs:
         container_name: streamr-dev-ipfs
         image: ipfs/go-ipfs:v0.11.0


### PR DESCRIPTION
The graph-deploy dockers will create a file in their volume, that indicates if they already ran. Running the container a second time should do nothing.
Before the fix the script in the container could not create the file because of a unsufficient permission, so the compile and deploy of the subgraph ran every time.
After the fix this works as intended, the first time the file is creates and the second time the files presence is detected and the actual build and deployment is skipped.