### PR TITLE
fix: 'sleep 10s' -> 'sleep 10'. 

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -179,7 +179,7 @@ wait() {
                 echo "Still waiting for the following services:"
                 for s in "${waiting_for_services[@]}"; do echo "$s"; done
             fi
-            sleep 10s
+            sleep 10
             time_waited=$((time_waited+10))
         else
             echo "All services up and running."


### PR DESCRIPTION
The `s` suffix does not seem to work on MacOS.
The `s` suffix has been there for 2 years, I don't know why it no longer works for me, but removing the `s` should work everywhere.

Default is seconds anyway.

```bash
> sleep 1s
usage: sleep seconds

>
```

```bash
> sleep 1

>
```