### PR TITLE
Fix platform tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,7 +305,7 @@ services:
             retries: 60
     platform:
         container_name: streamr-dev-platform
-        image: streamr/platform:dev
+        image: streamr/platform:latest
         networks:
             - streamr-network
         ports:


### PR DESCRIPTION
`streamr/platform:latest` is the image containing latest changes so that should be used. The old `dev` tag is not being built anymore.