### PR TITLE
fix: use full path to ifconfig

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -77,7 +77,7 @@ services() {
 }
 
 start() {
-    ip_lines=$(ifconfig | grep -c 10.200.10.1)
+    ip_lines=$(/sbin/ifconfig | grep -c 10.200.10.1)
     if [ "$ip_lines" -eq "0" ]; then
         COMMANDS_TO_RUN+=("echo Binding the internal IP address 10.200.10.1 to the loopback interface.")
         COMMANDS_TO_RUN+=("echo This requires sudo privileges, so please provide your password if requested")


### PR DESCRIPTION
Fixes error:
streamr-docker-dev: line 80: ifconfig: command not found

Where ifconfig is avaible but not in path on a self-hosted GA runner.