### PR TITLE
Update Brroker healthcheck endpoint url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
             CASSANDRA_HOST: 10.200.10.1:9042
         command: node bin/broker.js configs/docker-1.env.json
         healthcheck:
-            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8891/volume"]
+            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8891/info"]
             interval: 30s
             timeout: 10s
             retries: 20
@@ -222,7 +222,7 @@ services:
             STREAMR_URL: "${STREAMR_BASE_URL}"
         command: node bin/broker.js configs/docker-2.env.json
         healthcheck:
-            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8791/volume"]
+            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8791/info"]
             interval: 30s
             timeout: 10s
             retries: 20
@@ -246,7 +246,7 @@ services:
             STREAMR_URL: "${STREAMR_BASE_URL}"
         command: node bin/broker.js configs/docker-3.env.json
         healthcheck:
-            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8691/volume"]
+            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8691/info"]
             interval: 30s
             timeout: 10s
             retries: 20


### PR DESCRIPTION
Use `/info` endpoint provided by the new `info` plugin. Needs https://github.com/streamr-dev/network-monorepo/pull/565