### PR TITLE
fix: watcher also needs sidechain

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -285,6 +285,7 @@ services:
         restart: unless-stopped
         depends_on:
             - parity-node0
+            - parity-sidechain-node0
             - core-api
         environment:
             STREAMR_API_URL: "${STREAMR_BASE_URL}/api/v2"


### PR DESCRIPTION
this might change after sidechain is dropped from dev env, but for now that's where the registry contracts are.