### PR TITLE
refactor: use `npm exec` to start Tracker and Broker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
               read_only: true
               bind:
                   propagation: rprivate
-        command: node bin/tracker.js 0xe5abc5ee43b8830e7b0f98d03efff5d6cae574d52a43204528eab7b52cd6408d tracker-1 --port=30301 ${TRACKER_ARGS}
+        command: npm exec -- streamr-tracker 0xe5abc5ee43b8830e7b0f98d03efff5d6cae574d52a43204528eab7b52cd6408d tracker-1 --port=30301 ${TRACKER_ARGS}
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--insecure", "${STREAMR_BASE_URL}:30301/topology/"]
             interval: 30s
@@ -147,7 +147,7 @@ services:
               read_only: true
               bind:
                   propagation: rprivate
-        command: node bin/tracker.js 0x96de9d06f9e409119a2cd9b57dfc326f66d953a0418f3937b92c8930f930893c tracker-2 --port=30302 ${TRACKER_ARGS}
+        command: npm exec -- streamr-tracker 0x96de9d06f9e409119a2cd9b57dfc326f66d953a0418f3937b92c8930f930893c tracker-2 --port=30302 ${TRACKER_ARGS}
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--insecure", "${STREAMR_BASE_URL}:30302/topology/"]
             interval: 30s
@@ -169,7 +169,7 @@ services:
               read_only: true
               bind:
                   propagation: rprivate
-        command: node bin/tracker.js 0x6117b7a7cb8f3c8d40e3b7e87823c11af7f401515bc4fdf2bfdda70f1b833027 tracker-3 --port=30303 ${TRACKER_ARGS}
+        command: npm exec -- streamr-tracker 0x6117b7a7cb8f3c8d40e3b7e87823c11af7f401515bc4fdf2bfdda70f1b833027 tracker-3 --port=30303 ${TRACKER_ARGS}
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--insecure", "${STREAMR_BASE_URL}:30303/topology/"]
             interval: 30s
@@ -196,7 +196,7 @@ services:
         environment:
             STREAMR_URL: "${STREAMR_BASE_URL}"
             CASSANDRA_HOST: 10.200.10.1:9042
-        command: node bin/broker.js configs/docker-1.env.json
+        command: npm exec -- streamr-broker configs/docker-1.env.json
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8891/info"]
             interval: 30s
@@ -220,7 +220,7 @@ services:
             - tracker-3
         environment:
             STREAMR_URL: "${STREAMR_BASE_URL}"
-        command: node bin/broker.js configs/docker-2.env.json
+        command: npm exec -- streamr-broker configs/docker-2.env.json
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8791/info"]
             interval: 30s
@@ -244,7 +244,7 @@ services:
             - tracker-3
         environment:
             STREAMR_URL: "${STREAMR_BASE_URL}"
-        command: node bin/broker.js configs/docker-3.env.json
+        command: npm exec -- streamr-broker configs/docker-3.env.json
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost:8691/info"]
             interval: 30s


### PR DESCRIPTION
This way we don't need to know internal name/location of the `bin/tracker.js` / `bin/broker.js` script file. This PR is a dependency for https://github.com/streamr-dev/network/pull/1034.