### PR TITLE
ETH-488: bump graph-node to 0.30

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
+          - ubuntu-22.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3.5.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,6 +525,13 @@ services:
             ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8540'
             RUST_LOG: info
             GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
+            LC_COLLATE: "C"
+            LC_CTYPE: "C"
+            LC_MESSAGES: "C"
+            LC_MONETARY: "C"
+            LC_NUMERIC: "C"
+            LC_TIME: "C"
+            LC_ALL: "C"
         healthcheck:
             test: ["CMD", "echo"] # TODO: health check
             interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -502,7 +502,7 @@ services:
             - bridge-request
     graph-node:
         container_name: streamr-dev-thegraph-node
-        image: graphprotocol/graph-node:v0.27.0
+        image: graphprotocol/graph-node:v0.30.0
         restart: unless-stopped
         networks:
             - streamr-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,13 +525,6 @@ services:
             ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8540'
             RUST_LOG: info
             GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
-            LC_COLLATE: "C"
-            LC_CTYPE: "C"
-            LC_MESSAGES: "C"
-            LC_MONETARY: "C"
-            LC_NUMERIC: "C"
-            LC_TIME: "C"
-            LC_ALL: "C"
         healthcheck:
             test: ["CMD", "echo"] # TODO: health check
             interval: 10s
@@ -627,6 +620,7 @@ services:
             POSTGRES_USER: streamr
             POSTGRES_PASSWORD: let-me-in
             POSTGRES_DB: streamr
+            POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
         volumes:
             - type: volume
               source: data-postgres

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -15,7 +15,7 @@ DETACHED=1
 DRY_RUN=0
 FOLLOW=0
 WAIT=0
-WAIT_TIMEOUT=300     # seconds
+WAIT_TIMEOUT=500     # seconds
 DOCKER_COMPOSE="docker-compose --ansi never -f docker-compose.yml"
 if [ -n "${CI-}" ]; then # Apply CI override when running on CI server
 	DOCKER_COMPOSE="$DOCKER_COMPOSE -f docker-compose-ci.yml"


### PR DESCRIPTION
Quick manual testing didn't show any problems on my machine. Network-subgraphs tests pass.

On Sam's system, there were problems. We only get to see if everything breaks in CI after merging this, I'm afraid. So let's not do it before Monday...