### PR TITLE
Dev chain fast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3.5.2
       - name: Start Streamr Docker Stack
-        run: ./streamr-docker-dev/bin.sh start --wait --timeout 600
+        run: ./streamr-docker-dev/bin.sh start --except deploy-network-subgraphs --except graph-node --wait --timeout 600
       - name: Collect docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2.2.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3.5.2
       - name: Start Streamr Docker Stack
-        run: ./streamr-docker-dev/bin.sh start --except deploy-network-subgraphs --except graph-node --wait --timeout 600
+        run: ./streamr-docker-dev/bin.sh start --except deploy-network-subgraphs --except graph-node --except graph-deploy-tatum-subgraph --except graph-deploy-streamregistry-subgraph --except deploy-hub-subgraph --except graph-deploy-dataunion-subgraph --wait --timeout 600
       - name: Collect docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2.2.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -350,16 +350,16 @@ services:
         depends_on:
             - ipfs
             - postgres
-            # - parity-sidechain-node0
-            - dev-chain-fast
+            - parity-sidechain-node0   # for parity sidechain
+            # - dev-chain-fast         # for dev-chain-fast
         environment:
             postgres_host: postgres
             postgres_user: streamr
             postgres_pass: let-me-in
             postgres_db: streamr
             ipfs: 'streamr-dev-ipfs:5001'
-            # ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8545'
-            ethereum: 'xDai:http://streamr-dev-chain-fast:8545'  # for dev-chain-fast
+            ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8540'   # for parity sidechain
+            # ethereum: 'xDai:http://streamr-dev-chain-fast:8545'             # for dev-chain-fast
             RUST_LOG: info
             GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,27 +302,41 @@ services:
         container_name: streamr-dev-parity-sidechain-node0
         environment:
             CHAIN_ID: 0x2325
-        # image: streamr/dev-chain-fast:latest
-        image: streamr/dev-chain-fast
+        image: streamr/open-ethereum-poa-sidechain-preload1:dev
         networks:
             - streamr-network
         ports:
-            - "8546:8545"
-            # - "8451:8450"
-            # - "30310:30309"
+            - "8546:8540"
+            - "8451:8450"
+            - "30310:30309"
         restart: unless-stopped
         healthcheck:
-            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8545/api/health"]
+            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8540/api/health"]
             interval: 1m30s
             timeout: 10s
             retries: 3
-        # command: --chain ./streamr-spec.json --config ./node0.toml
+        command: --chain ./streamr-spec.json --config ./node0.toml
         volumes:
             - type: volume
               source: data-parity-sidechain-node0
               target: /home/parity/parity_data
               volume:
                   nocopy: true
+    dev-chain-fast:
+        container_name: streamr-dev-chain-fast
+        environment:
+            CHAIN_ID: 0x31337
+        image: streamr/dev-chain-fast
+        networks:
+            - streamr-network
+        ports:
+            - "8547:8545"
+        restart: unless-stopped
+        healthcheck:
+            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8545/api/health"]
+            interval: 1m30s
+            timeout: 10s
+            retries: 3
     graph-node:
         container_name: streamr-dev-thegraph-node
         image: graphprotocol/graph-node:v0.30.0
@@ -338,14 +352,16 @@ services:
         depends_on:
             - ipfs
             - postgres
-            - parity-sidechain-node0
+            # - parity-sidechain-node0
+            - dev-chain-fast
         environment:
             postgres_host: postgres
             postgres_user: streamr
             postgres_pass: let-me-in
             postgres_db: streamr
             ipfs: 'streamr-dev-ipfs:5001'
-            ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8545'
+            # ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8545'
+            ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8547'  # for dev-chain-fast
             RUST_LOG: info
             GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,20 +302,21 @@ services:
         container_name: streamr-dev-parity-sidechain-node0
         environment:
             CHAIN_ID: 0x2325
-        image: streamr/open-ethereum-poa-sidechain-preload1:dev
+        # image: streamr/dev-chain-fast:latest
+        image: streamr/dev-chain-fast:latest
         networks:
             - streamr-network
         ports:
-            - "8546:8540"
-            - "8451:8450"
-            - "30310:30309"
+            - "8546:8545"
+            # - "8451:8450"
+            # - "30310:30309"
         restart: unless-stopped
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8540/api/health"]
             interval: 1m30s
             timeout: 10s
             retries: 3
-        command: --chain ./streamr-spec.json --config ./node0.toml
+        # command: --chain ./streamr-spec.json --config ./node0.toml
         volumes:
             - type: volume
               source: data-parity-sidechain-node0
@@ -344,7 +345,7 @@ services:
             postgres_pass: let-me-in
             postgres_db: streamr
             ipfs: 'streamr-dev-ipfs:5001'
-            ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8540'
+            ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8545'
             RUST_LOG: info
             GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -350,16 +350,44 @@ services:
         depends_on:
             - ipfs
             - postgres
-            # - parity-sidechain-node0   # for parity sidechain
-            - dev-chain-fast         # for dev-chain-fast
+            - parity-sidechain-node0
         environment:
             postgres_host: postgres
             postgres_user: streamr
             postgres_pass: let-me-in
             postgres_db: streamr
             ipfs: 'streamr-dev-ipfs:5001'
-            # ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8540'   # for parity sidechain
-            ethereum: 'xDai:http://streamr-dev-chain-fast:8545'             # for dev-chain-fast
+            ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8540'
+            RUST_LOG: info
+            GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
+        healthcheck:
+            test: ["CMD", "nc", "-z", "localhost", "8000"]
+            interval: 5s
+            timeout: 10s
+            retries: 10
+    graph-node-fastchain:
+        container_name: streamr-dev-thegraph-node
+        image: graphprotocol/graph-node:v0.30.0
+        restart: unless-stopped
+        networks:
+            - streamr-network
+        ports:
+            - '8000:8000'
+            - '8001:8001'
+            - '8020:8020'
+            - '8030:8030'
+            - '8040:8040'
+        depends_on:
+            - ipfs
+            - postgres
+            - dev-chain-fast
+        environment:
+            postgres_host: postgres
+            postgres_user: streamr
+            postgres_pass: let-me-in
+            postgres_db: streamr
+            ipfs: 'streamr-dev-ipfs:5001'
+            ethereum: 'xDai:http://streamr-dev-chain-fast:8545'
             RUST_LOG: info
             GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
         healthcheck:
@@ -383,12 +411,26 @@ services:
                   nocopy: false
     deploy-network-subgraphs:
         container_name: streamr-dev-deploy-network-subgraphs
-        image: streamr/deploy-network-subgraphs:dev-fastchain
+        image: streamr/deploy-network-subgraphs:dev
         restart: on-failure # exits on success
         networks:
             - streamr-network
         depends_on:
             - graph-node
+        volumes:
+            - type: volume
+              source: data-graph-deploy
+              target: /firstrun
+              volume:
+                  nocopy: false
+    deploy-network-subgraphs-fastchain:
+        container_name: streamr-dev-deploy-network-subgraphs
+        image: streamr/deploy-network-subgraphs:dev-fastchain
+        restart: on-failure # exits on success
+        networks:
+            - streamr-network
+        depends_on:
+            - graph-node-fastchain
         volumes:
             - type: volume
               source: data-graph-deploy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -324,7 +324,7 @@ services:
                   nocopy: true
     dev-chain-fast:
         container_name: streamr-dev-chain-fast
-        image: streamr/dev-chain-fast
+        image: streamr/dev-chain-fast:dev
         networks:
             - streamr-network
         ports:
@@ -350,16 +350,16 @@ services:
         depends_on:
             - ipfs
             - postgres
-            - parity-sidechain-node0   # for parity sidechain
-            # - dev-chain-fast         # for dev-chain-fast
+            # - parity-sidechain-node0   # for parity sidechain
+            - dev-chain-fast         # for dev-chain-fast
         environment:
             postgres_host: postgres
             postgres_user: streamr
             postgres_pass: let-me-in
             postgres_db: streamr
             ipfs: 'streamr-dev-ipfs:5001'
-            ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8540'   # for parity sidechain
-            # ethereum: 'xDai:http://streamr-dev-chain-fast:8545'             # for dev-chain-fast
+            # ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8540'   # for parity sidechain
+            ethereum: 'xDai:http://streamr-dev-chain-fast:8545'             # for dev-chain-fast
             RUST_LOG: info
             GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
         healthcheck:
@@ -383,7 +383,7 @@ services:
                   nocopy: false
     deploy-network-subgraphs:
         container_name: streamr-dev-deploy-network-subgraphs
-        image: streamr/deploy-network-subgraphs:dev
+        image: streamr/deploy-network-subgraphs:dev-fastchain
         restart: on-failure # exits on success
         networks:
             - streamr-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -324,8 +324,6 @@ services:
                   nocopy: true
     dev-chain-fast:
         container_name: streamr-dev-chain-fast
-        environment:
-            CHAIN_ID: 0x31337
         image: streamr/dev-chain-fast
         networks:
             - streamr-network
@@ -361,7 +359,7 @@ services:
             postgres_db: streamr
             ipfs: 'streamr-dev-ipfs:5001'
             # ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8545'
-            ethereum: 'xDai:http://streamr-dev-parity-sidechain-node0:8547'  # for dev-chain-fast
+            ethereum: 'xDai:http://streamr-dev-chain-fast:8545'  # for dev-chain-fast
             RUST_LOG: info
             GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: "true"
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,7 +303,7 @@ services:
         environment:
             CHAIN_ID: 0x2325
         # image: streamr/dev-chain-fast:latest
-        image: streamr/dev-chain-fast:latest
+        image: streamr/dev-chain-fast
         networks:
             - streamr-network
         ports:
@@ -312,7 +312,7 @@ services:
             # - "30310:30309"
         restart: unless-stopped
         healthcheck:
-            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8540/api/health"]
+            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8545/api/health"]
             interval: 1m30s
             timeout: 10s
             retries: 3


### PR DESCRIPTION
added subgraph-deploy-container, graph-node config, and fastchain containers in a non-breaking way, now the old setup with the sidechain can be started Or alternatively the new fastchain can be started.
Both work on the same docker-compose and there is no need to edit anything.
The existing integrationtests should not be affected by this at all.

Only thing that might break is starting EVERYTHING from the docker-compose, then one of the two graph-node configs will probably not work