### PR TITLE
`wipe` prunes all volumes

### DIFF
--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -223,7 +223,7 @@ update() {
 wipe() {
     stop
     COMMANDS_TO_RUN+=("echo Wiping persistent data of services")
-    COMMANDS_TO_RUN+=("docker volume prune -f")
+    COMMANDS_TO_RUN+=("docker volume prune --all --force")
 }
 
 factory-reset() {


### PR DESCRIPTION
Before this change the `wipe` command pruned only anonymous volumes (https://docs.docker.com/engine/reference/commandline/volume_prune/). The `--all `argument was added so that the command prune also other volumes.

## Open questions

Would it make sense to add labels to all `streamr-docker-dev` images? We could `--filter` so that we don't prune some volume that is not related to `streamr-docker-dev`.