### PR TITLE
NET-1014: try different IPFS healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -453,9 +453,9 @@ services:
         environment:
             IPFS_PROFILE: server # sets the server profile
         healthcheck:
-            test: ["CMD", "ipfs", "id"]
-            interval: 5s
-            timeout: 10s
+            test: ["CMD-SHELL", "ipfs --api=/ip4/127.0.0.1/tcp/5001 dag stat /ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn || exit 1"] # from official image
+            interval: 10s
+            timeout: 3s
             retries: 10
     dev-chain-fast:
         container_name: streamr-dev-chain-fast


### PR DESCRIPTION
Updating IPFS alone didn't work so solve the flaky CI issue https://github.com/streamr-dev/network/actions/runs/6013462889/job/16311114004.

Next idea: copy healthcheck from their official docker image https://github.com/ipfs/kubo/blob/master/Dockerfile#L100-L103