### PR TITLE
chore: fix indentation error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,7 @@ services:
         ports:
             - "3334:80"
         depends_on:
-          - entry-point
+            - entry-point
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "http://localhost"]
             interval: 10s


### PR DESCRIPTION
Before this PR the `lint` job in CI failed with the following error:
```
Run ibiqlik/action-yamllint@v3.1
Run # export LOGFILE=$(mktemp yamllint-XXXXXX)
======================
= Linting YAML files =
======================
Error: r-compose.yml:2[19](https://github.com/streamr-dev/streamr-docker-dev/actions/runs/12747880739/job/35526872513#step:3:21):11: [error] wrong indentation: expected 12 but found 10 (indentation)
Error: Process completed with exit code 1.
```