### PR TITLE
fix: [DEVOP-296] Do not exclude `entry-point` service

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4.0.0
       - name: Start Streamr Docker Stack
-        # TODO the entry-point service is temporarily disabled as broker images are not yet built from streamr-1.0 branch
-        run: ./streamr-docker-dev/bin.sh start --wait --timeout 600 --except entry-point
+        run: ./streamr-docker-dev/bin.sh start --wait --timeout 600
       - name: Collect docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2.2.1


### PR DESCRIPTION
Removed `entry-point` exclusion from the "Start Streamr Docker Stack" CI task.

## Background

The `streamr/node` images have already been updated to Streamr 1.0 era (https://github.com/streamr-dev/network/blob/main/Dockerfile.node). Therefore we don't need to exclude the `entry-point` anymore.