### PR TITLE
chore: Upgrade `ubuntu` CI runner versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4.0.0


### PR DESCRIPTION
## Background

Ubuntu 20.04 has been deprecated in GitHub. The jobs using ubuntu-20.04 runner no longer runs. In the logs there is error:
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```

(e.g. https://github.com/streamr-dev/streamr-docker-dev/actions/runs/14733830602/job/41354733466)

## Changes

Upgraded versions. Now using `ubuntu` 22 and 24 instead of 20 and 22.