### PR TITLE
chore: [ETH-727] Clean up old Parity chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ If you know what services you need, you don't need to use the `bin.sh`, you can 
 
 3. Bind the loopback interface to 10.200.10.1: `netsh int ip add address "Loopback" 10.200.10.1`
 
-4. For instance, for the Ethereum environment without core-api: `docker-compose up parity-node0 parity-sidechain-node0 bridge`
-
 ## Quickstart
 
 **Option 1**
@@ -58,7 +56,7 @@ If you know what services you need, you don't need to use the `bin.sh`, you can 
 
 ### Interacting with the local blockchain
 
-The local Streamr Stack is configured to interact with the local Ethereum Parity node. Transactions should be near instant.
+The local Streamr Stack is configured to interact with the local Ethereum node. Transactions should be near instant.
 
 The recommended way to interact with the blockchain is through Metamask. Here is the network configuration to add:
 - Network Name: Streamr Local
@@ -233,8 +231,7 @@ streamr-docker-dev start --wait
 ### Supporting services
 - 1 x MySQL instance
 - 1 x Apache Cassandra instance with `streamr_dev` keyspace
-- 1 x [Ethereum Parity node ("mainchain")](https://github.com/streamr-dev/open-ethereum-poa)
-- 1 x [Ethereum Parity node ("sidechain")](https://github.com/streamr-dev/open-ethereum-poa)
+- 1 x Ethereum node
 - 1 x Postgres DB for TheGraph
 - 1 x ipfs for TheGraph
 - 1 x adapter for ENS queries from sidechain to mainchain

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -56,22 +56,6 @@ services:
                     memory: 50M
                 reservations:
                     memory: 10M
-    parity-node0:
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 100M
-                reservations:
-                    memory: 20M
-    parity-sidechain-node0:
-        deploy:
-            resources:
-                limits:
-                    cpus: '1.0'
-                    memory: 100M
-                reservations:
-                    memory: 20M
     ipfs:
         deploy:
             resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,54 +178,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 60
-    parity-node0:
-        container_name: streamr-dev-parity-node0
-        environment:
-            CHAIN_ID: 0x2323
-        image: streamr/open-ethereum-poa-mainchain-preload1:dev
-        networks:
-            - streamr-network
-        ports:
-            - "8545:8540"
-            - "8450:8450"
-            - "30309:30309"
-        restart: unless-stopped
-        healthcheck:
-            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8540/api/health"]
-            interval: 1m30s
-            timeout: 10s
-            retries: 3
-        command: --chain ./streamr-spec.json --config ./node0.toml
-        volumes:
-            - type: volume
-              source: data-parity-node0
-              target: /home/parity/parity_data
-              volume:
-                  nocopy: true
-    parity-sidechain-node0:
-        container_name: streamr-dev-parity-sidechain-node0
-        environment:
-            CHAIN_ID: 0x2325
-        image: streamr/open-ethereum-poa-sidechain-preload1:dev
-        networks:
-            - streamr-network
-        ports:
-            - "8546:8540"
-            - "8451:8450"
-            - "30310:30309"
-        restart: unless-stopped
-        healthcheck:
-            test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8540/api/health"]
-            interval: 1m30s
-            timeout: 10s
-            retries: 3
-        command: --chain ./streamr-spec.json --config ./node0.toml
-        volumes:
-            - type: volume
-              source: data-parity-sidechain-node0
-              target: /home/parity/parity_data
-              volume:
-                  nocopy: true
     graph-deploy-dataunion-subgraph-fastchain:
         container_name: streamr-dev-graph-deploy-dataunion-subgraph-fastchain
         image: streamr/graph-deploy-dataunion-subgraph:dev-fastchain
@@ -376,8 +328,6 @@ volumes:
     cassandra_init_scripts:
     data-mysql:
     data-cassandra:
-    data-parity-node0:
-    data-parity-sidechain-node0:
     data-ipfs:
     data-postgres-fastchain:
     data-graph-deploy-fastchain:

--- a/streamr-docker-dev/help_scripts.sh
+++ b/streamr-docker-dev/help_scripts.sh
@@ -47,7 +47,7 @@ Usage: streamr-docker-dev start [--] <service>...
 
 Examples:
     streamr-docker-dev start
-    streamr-docker-dev start tracker-1 parity-node0
+    streamr-docker-dev start tracker-1
     streamr-docker-dev start --except tracker-1 --wait
 
 Options:
@@ -65,7 +65,7 @@ Usage: streamr-docker-dev stop [options] [--] <service>...
 
 Examples:
     streamr-docker-dev stop
-    streamr-docker-dev stop tracker-1 parity-node0
+    streamr-docker-dev stop tracker-1
 "
 }
 
@@ -77,7 +77,7 @@ Usage: streamr-docker-dev restart [options] [--] <service>...
 
 Examples:
     streamr-docker-dev restart
-    streamr-docker-dev restart tracker-1 parity-node0
+    streamr-docker-dev restart tracker-1
 "
 }
 
@@ -116,8 +116,8 @@ Usage: streamr-docker-dev log [[options] [--] <service>...]
 
 Examples:
     streamr-docker-dev log
-    streamr-docker-dev log tracker-1 parity-node0
-    streamr-docker-dev log -f tracker-1 parity-node0
+    streamr-docker-dev log tracker-1
+    streamr-docker-dev log -f tracker-1
 
 Options:
     -f --follow        	    follow log in realtime
@@ -143,7 +143,7 @@ Usage: streamr-docker-dev pull [ [--] <service>...]
 
 Examples:
     streamr-docker-dev pull
-    streamr-docker-dev pull tracker-1 parity-node0
+    streamr-docker-dev pull tracker-1
 "
 }
 


### PR DESCRIPTION
Removed some deprecated services.

These have `fastchain` counterparts and therefore deprecated:
- `graph-node`
- `deploy-network-subgraphs`
- `graph-deploy-dataunion-subgraph`
- `postgres`
- `ens-sync-script`

These used the deprecated `graph-node` service:
- `deploy-hub-subgraph`
- `graph-deploy-streamregistry-subgraph`
- `graph-deploy-tatum-subgraph`

These are the old Parity chain services, nowadays replaced by `dev-chain-fast`.
