### PR TITLE
chore: Optimize `dev-chain-fast` healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -371,9 +371,9 @@ services:
         restart: unless-stopped
         healthcheck:
             test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--max-time", "9", "--header", "Content-Type: application/json", "--data", '[{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}]', "http://localhost:8545/api/health"]
-            interval: 1m30s
-            timeout: 10s
-            retries: 3
+            interval: 10s
+            timeout: 1s
+            retries: 10
     graph-node-fastchain:
         container_name: streamr-dev-thegraph-node-fastchain
         image: graphprotocol/graph-node:v0.32.0

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -179,7 +179,7 @@ wait() {
                 for s in "${waiting_for_services[@]}"; do echo "$s"; done
             fi
             sleep 1s
-            time_waited=$((time_waited+5))
+            time_waited=$((time_waited+1))
         else
             echo "All services up and running."
             break

--- a/streamr-docker-dev/bin.sh
+++ b/streamr-docker-dev/bin.sh
@@ -173,12 +173,12 @@ wait() {
         done
 
         if [ ${#waiting_for_services[@]} -gt 0 ]; then
-            if (( time_waited >= 60 )); then
+            if (( time_waited >= 30 )); then
                 echo "***********************************"
                 echo "Still waiting for the following services:"
                 for s in "${waiting_for_services[@]}"; do echo "$s"; done
             fi
-            sleep 5
+            sleep 1s
             time_waited=$((time_waited+5))
         else
             echo "All services up and running."


### PR DESCRIPTION
There was very long interval for the healthcheck of `dev-chain-fast`. That's why the startup of `streamr-docker-dev` chain services was usually very slow. Reduced the interval significantly.

Also improved `--wait` arg to log warnings sooner, and reduced the poll interval so that we can exit polling sooner. 

## Statistics

Before this PR typical chain service startup took about 90s, now it takes about 24s.

```
streamr-docker-dev wipe
time streamr-docker-dev start dev-chain-fast deploy-network-subgraphs-fastchain --wait
```