### PR TITLE
fix: Use exact version number for `postgress`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,7 +272,7 @@ services:
                   nocopy: false
     postgres-fastchain:
         container_name: streamr-dev-postgres-fastchain
-        image: postgres
+        image: postgres:17
         restart: unless-stopped
         networks:
             - streamr-network


### PR DESCRIPTION
Before this PR the `postgres` service didn't specify any version number. I.e. used the latest version . When v18 was released on [2025-09-25](https://www.postgresql.org/about/news/postgresql-18-released-3142/), we started to get this error in [network monorepo's GitHub action logs](https://github.com/streamr-dev/network/actions/runs/18105969844/job/51528093133?pr=3211):
```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/var/lib/docker/volumes/streamr-docker-dev_data-postgres-fastchain/_data" to rootfs at "/var/lib/postgresql/data": change mount propagation through procfd: open o_path procfd: open /var/lib/docker/overlay2/1064c70ea0d33db456a30333bef5a49e1cbf1a98b4d097def04149a63bca145f/merged/var/lib/postgresql/data: no such file or directory: unknown
streamr-docker-dev: error while running command: "docker compose --ansi never -f docker-compose.yml  -f docker-compose-ci.yml up  -d --remove-orphans cassandra init-keyspace dev-chain-fast deploy-network-subgraphs-fastchain broker-node-storage-1 entry-point "
```

Most likely there is some incompatibility with v18. As v17 worked ok, we use that version now in `docker-compose.yml`.